### PR TITLE
Fixed error handling on errors in json parsing

### DIFF
--- a/requests_ms_auth/session.py
+++ b/requests_ms_auth/session.py
@@ -1,6 +1,5 @@
 import logging
 import pprint
-import sys
 from simplejson.errors import JSONDecodeError
 from typing import Optional, Dict, Tuple
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,6 +2,4 @@ adal~=1.2
 msal~=1.1.0
 requests>=2.0.0
 requests_oauthlib~=1.2.0
-
-
-
+simplejson~=3.17

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,5 +17,6 @@ pyjwt[crypto]==1.7.1      # via adal, msal
 python-dateutil==2.8.1    # via adal
 requests-oauthlib==1.2.0  # via -r requirements/temp_requirements.in
 requests==2.23.0          # via -r requirements/temp_requirements.in, adal, msal, requests-oauthlib
+simplejson==3.17.0        # via -r requirements/temp_requirements.in
 six==1.14.0               # via cryptography, python-dateutil
 urllib3==1.25.8           # via requests

--- a/tests/test_MsRequestsSession.py
+++ b/tests/test_MsRequestsSession.py
@@ -169,10 +169,9 @@ def todo_test_all(auth_config_live_adal):
             # Verification
             ok, message = session.verify_auth()
             assert ok
-            logger.warning(f"mess: {message}")
-            assert False
+            logger.warning(f"Message: {message}")
             # Direct
-            res = session.get(session.raa_verification_url)
+            res = session.get(session.msrs_verification_url)
             assert_json_response(res, verification_element)
             # Prepared
             req = requests.Request("GET", verification_url)


### PR DESCRIPTION
Fixed a bug when checking for json element failed:

from simplejson.errors import JSONDecodeError
instead of 
from json import JSONDecodeError

Or else the correct exception was not caught